### PR TITLE
#28 due to multiple reports changing logic to do full clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ LABEL maintainer="sparklyballs"
 RUN \
  echo "**** install system packages ****" && \
  apk add --no-cache \
+	git \
 	nodejs && \
  echo "**** install pip packages ****" && \
  pip install --no-cache-dir -U \
@@ -22,14 +23,9 @@ RUN \
 	MYLAR_COMMIT=$(curl -sX GET https://api.github.com/repos/evilhero/mylar/commits/master \
 	| awk '/sha/{print $4;exit}' FS='[""]'); \
  fi && \
- mkdir -p \
-   /app/mylar && \
- curl -o \
- /tmp/mylar.tar.gz -L \
-	"https://github.com/evilhero/mylar/archive/${MYLAR_COMMIT}.tar.gz" && \
- tar xf \
- /tmp/mylar.tar.gz -C \
-	/app/mylar --strip-components=1 && \
+ git clone https://github.com/evilhero/mylar.git /app/mylar && \
+ cd /app/mylar && \
+ git checkout ${MYLAR_COMMIT} && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/root/.cache \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -13,6 +13,7 @@ LABEL maintainer="sparklyballs"
 RUN \
  echo "**** install system packages ****" && \
  apk add --no-cache \
+	git \
 	nodejs && \
  echo "**** install pip packages ****" && \
  pip install --no-cache-dir -U \
@@ -25,14 +26,9 @@ RUN \
 	MYLAR_COMMIT=$(curl -sX GET https://api.github.com/repos/evilhero/mylar/commits/master \
 	| awk '/sha/{print $4;exit}' FS='[""]'); \
  fi && \
- mkdir -p \
-   /app/mylar && \
- curl -o \
- /tmp/mylar.tar.gz -L \
-	"https://github.com/evilhero/mylar/archive/${MYLAR_COMMIT}.tar.gz" && \
- tar xf \
- /tmp/mylar.tar.gz -C \
-	/app/mylar --strip-components=1 && \
+ git clone https://github.com/evilhero/mylar.git /app/mylar && \
+ cd /app/mylar && \
+ git checkout ${MYLAR_COMMIT} && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/root/.cache \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -13,6 +13,7 @@ LABEL maintainer="sparklyballs"
 RUN \
  echo "**** install system packages ****" && \
  apk add --no-cache \
+	git \
 	nodejs && \
  echo "**** install pip packages ****" && \
  pip install --no-cache-dir -U \
@@ -25,14 +26,9 @@ RUN \
 	MYLAR_COMMIT=$(curl -sX GET https://api.github.com/repos/evilhero/mylar/commits/master \
 	| awk '/sha/{print $4;exit}' FS='[""]'); \
  fi && \
- mkdir -p \
-   /app/mylar && \
- curl -o \
- /tmp/mylar.tar.gz -L \
-	"https://github.com/evilhero/mylar/archive/${MYLAR_COMMIT}.tar.gz" && \
- tar xf \
- /tmp/mylar.tar.gz -C \
-	/app/mylar --strip-components=1 && \
+ git clone https://github.com/evilhero/mylar.git /app/mylar && \
+ cd /app/mylar && \
+ git checkout ${MYLAR_COMMIT} && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/root/.cache \


### PR DESCRIPTION
Might seem heavy handed to have a full git tree, but all of the versioning logic in the app depends on it. It is not the leanest way but the most futureproof as long as the application does not do any kind of release tagging. 