### PR TITLE
hold comictagger back to work with Python2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
 	nodejs && \
  echo "**** install pip packages ****" && \
  pip install --no-cache-dir -U \
-	comictagger \
+	comictagger==1.1.32rc1 \
 	configparser \
 	html5lib \
 	requests \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,7 +14,7 @@ RUN \
 	nodejs && \
  echo "**** install pip packages ****" && \
  pip install --no-cache-dir -U \
-	comictagger \
+	comictagger==1.1.32rc1 \
 	configparser \
 	html5lib \
 	requests \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -14,7 +14,7 @@ RUN \
 	nodejs && \
  echo "**** install pip packages ****" && \
  pip install --no-cache-dir -U \
-	comictagger \
+	comictagger==1.1.32rc1 \
 	configparser \
 	html5lib \
 	requests \


### PR DESCRIPTION
This project does not look like it will move to Python3. Need to hold back comictagger that requires python3 now. 